### PR TITLE
add language area in previewArea

### DIFF
--- a/src/components/PreviewArea.vue
+++ b/src/components/PreviewArea.vue
@@ -3,10 +3,14 @@
     <v-card-title>Preview</v-card-title>
 
     <v-card-text>
+      <h3>Language</h3>
+      <br>
+      <div id="language-preview-area" v-html="langSkillList">
+      </div>
+
       <h3>Front-End</h3>
       <br>
       <div id="front-end-preview-area" v-html="skillList">
-        <!-- <img src="https://img.shields.io/badge/html-E34F26?style=flat-square&logo=html5&logoColor=white"> -->
       </div>
     </v-card-text>
     
@@ -18,7 +22,10 @@ export default {
   props: {
     skillList: {
       type: String
-    }
+    },
+    langSkillList: {
+      type: String
+    },
   },
 }
 </script>


### PR DESCRIPTION
#8 
Added language skill list above front skill list in PreviewArea.
Because PreviewArea only receives html and shows it, it is expected that it will not matter much if the code is long.